### PR TITLE
[fix] rowを初期化した後に再読み込みしていなかった

### DIFF
--- a/AtCoderACPercentage.js
+++ b/AtCoderACPercentage.js
@@ -118,7 +118,10 @@
         //結果を表示するテーブルを作成する。
         //行を取得
         let row = document.getElementById('ac-percentage-row');
-        if (!row) initView();
+        if (!row) {
+            initView();
+            row = document.getElementById('ac-percentage-row');
+        }
 
         for (let i = 1; i < problemNames.length + 1; i++) {
             let cell = row.children[i];


### PR DESCRIPTION
#9 で実装したリロード時にinitを切り離したんですが、initした後の読み込みを忘れていました。テスト不足でした。本当に申し訳ないです。